### PR TITLE
fix(ci): fix syntax error in enforce-pr-target workflow

### DIFF
--- a/.github/workflows/enforce-pr-target.yml
+++ b/.github/workflows/enforce-pr-target.yml
@@ -38,21 +38,20 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `## ❌ Pull Request Target Error
+              body: \`## ❌ Pull Request Target Error
 
+            This PR is targeting the \\\`main\\\` branch, which is not allowed.
 
+            ### Required Workflow
+            All pull requests must target the \\\`dev\\\` branch first:
+            1. ✅ Feature branches → \\\`dev\\\`
+            2. ✅ After testing in \\\`dev\\\`, maintainers merge \\\`dev\\\` → \\\`main\\\`
 
-### Required Workflow
-#This PR is targeting the \`main\` branch, which is not allowed.
-#All pull requests must target the \`dev\` branch first:
-# 1. ✅ Feature branches → \`dev\`
-# 2. ✅ After testing in \`dev\`, maintainers merge \`dev\` → \`main\`
+            ### How to Fix
+            You can change the target branch of this PR:
+            1. Click the **"Edit"** button next to the PR title
+            2. Change the **base branch** from \\\`main\\\` to \\\`dev\\\`
+            3. The checks will automatically re-run
 
-# ### How to Fix
-# You can change the target branch of this PR:
-# 1. Click the **"Edit"** button next to the PR title
-# 2. Change the **base branch** from \`main\` to \`dev\`
-# 3. The checks will automatically re-run
-
-# Or close this PR and create a new one targeting \`dev\`.`
-#             })
+            Or close this PR and create a new one targeting \\\`dev\\\`.\`
+            })


### PR DESCRIPTION
Fixes the GitHub Actions syntax error preventing the dev→main PR (#98) from passing checks.

**Problem:**
The enforce-pr-target workflow had a SyntaxError due to improper YAML/JavaScript template literal formatting.

**Changes:**
- Removed YAML comment symbols (#) that were breaking JavaScript template literal
- Properly escaped backticks in the GitHub comment body
- Fixes: `SyntaxError: Unexpected end of input`

**Testing:**
This fix allows PR #98 (dev→main) to run all GitHub Actions checks properly.

Closes the blocking CI issue for the dev→main merge.