### PR TITLE
fix(ci): allow dev→main PRs in enforce-pr-target workflow

### DIFF
--- a/.github/workflows/enforce-pr-target.yml
+++ b/.github/workflows/enforce-pr-target.yml
@@ -13,13 +13,25 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - name: Check PR target branch
+      - name: Check out code
+        uses: actions/checkout@v4
+      
+      - name: Check PR source branch
         run: |
+          SOURCE_BRANCH="${{ github.head_ref }}"
+          
+          if [ "$SOURCE_BRANCH" = "dev" ]; then
+            echo "✅ Allowing dev → main PR (official release process)"
+            exit 0
+          fi
+          
           echo "❌ ERROR: Direct pull requests to 'main' are not allowed!"
           echo ""
           echo "This project follows a dev → main workflow:"
           echo "  1. Create PRs targeting 'dev' branch"
           echo "  2. After approval and testing in dev, maintainers will merge dev → main"
+          echo ""
+          echo "Current PR: $SOURCE_BRANCH → main"
           echo ""
           echo "Please close this PR and create a new one targeting 'dev' instead."
           echo ""
@@ -30,7 +42,7 @@ jobs:
           exit 1
 
       - name: Comment on PR
-        if: always()
+        if: failure()
         uses: actions/github-script@v7
         with:
           script: |
@@ -40,7 +52,7 @@ jobs:
               repo: context.repo.repo,
               body: \`## ❌ Pull Request Target Error
 
-            This PR is targeting the \\\`main\\\` branch, which is not allowed.
+            This PR is targeting the \\\`main\\\` branch from \\\`${{ github.head_ref }}\\\`, which is not allowed.
 
             ### Required Workflow
             All pull requests must target the \\\`dev\\\` branch first:


### PR DESCRIPTION
Fixes the GitHub Actions workflow to allow dev→main PRs while still blocking direct feature branch PRs to main.

**Problem:**
The enforce-pr-target workflow was blocking ALL PRs to main, including the official dev→main release process.

**Changes:**
- Added logic to check source branch and allow dev → main PRs
- Only blocks feature branches and other non-dev PRs to main
- Changed comment trigger from `always()` to `failure()` to only comment on blocked PRs
- Allows official release process while protecting main branch

**Testing:**
After merging this, PR #98 (dev→main) should pass the enforce-pr-target check.

**Related:**
- Fixes blocking issue on PR #98
- Complements the syntax fix from PR #99